### PR TITLE
Bug/3: Dialog is in front of the Coaching View

### DIFF
--- a/src/app/views/stage-browse-view/stage-detail-dialog/stage-detail-dialog.component.html
+++ b/src/app/views/stage-browse-view/stage-detail-dialog/stage-detail-dialog.component.html
@@ -26,7 +26,7 @@
             <p class="contact-tel-lable">{{stageContactTel}}</p>
             <p class="contact-mail-lable">{{stageContactEmail}}</p>
             <h3>Coaching</h3>
-            <p class="coching-describtion-lable">Entdecke das <a [routerLink]="['/app-coaching-view']">Coaching Angebot</a> der Stadt Zürich.
+            <p class="coching-describtion-lable">Entdecke das <a [routerLink]="['/app-coaching-view']" mat-dialog-close>Coaching Angebot</a> der Stadt Zürich.
             </p>
             <mat-divider></mat-divider>
             <button mat-flat-button class="applyBtn" (click)="show=!show">Bewerben</button>


### PR DESCRIPTION
I wrote the mat-dialog-close method after the router link of the CoachingView. Through this it has disappeared.